### PR TITLE
Feat/send signed messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/go-chi/chi v4.0.2+incompatible
+	github.com/go-chi/docgen v1.0.5 // indirect
 	github.com/go-chi/render v1.0.1
 	github.com/golangci/golangci-lint v1.19.1 // indirect
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,11 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-chi/chi v4.0.0+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
+github.com/go-chi/docgen v1.0.5 h1:TiGvJAuVPZJ9zFSwoF52eORe0SztOYqf9C79LVw/xbY=
+github.com/go-chi/docgen v1.0.5/go.mod h1:Nm4H4RaynSlvTexxWYWwXBzrwZKRE00MrkIIcJelhWM=
 github.com/go-chi/render v1.0.1 h1:4/5tis2cKaNdnv9zFLfXzcquC9HbeZgCnxGnKrltBS8=
 github.com/go-chi/render v1.0.1/go.mod h1:pq4Rr7HbnsdaeHagklXub+p6Wd16Af5l9koip1OvJns=
 github.com/go-critic/go-critic v0.3.5-0.20190904082202-d79a9f0c64db h1:GYXWx7Vr3+zv833u+8IoXbNnQY0AdXsxAgI0kX7xcwA=
@@ -129,6 +132,7 @@ github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUP
 github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -276,6 +280,7 @@ golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20180911220305-26e67e76b6c3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190110200230-915654e7eabc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7 h1:C2F/nMkR/9sfUTpvR3QrjBuTdvMUC/cFajkphs1YLQo=
 golang.org/x/net v0.0.0-20190227160552-c95aed5357e7/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/handlers/v1/actor_handler_test.go
+++ b/handlers/v1/actor_handler_test.go
@@ -36,7 +36,7 @@ func TestActor_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Callback errors are returned w/ server error status", func(t *testing.T) {
-		errs := types.MarshalErrors([]string{"this is an error"})
+		errs := types.MarshalErrorStrings("this is an error")
 
 		acb := func(actorId string) (*types.Actor, error) {
 			return nil, errors.New("this is an error")

--- a/handlers/v1/actors_handler_test.go
+++ b/handlers/v1/actors_handler_test.go
@@ -55,7 +55,7 @@ func TestActorsHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("Returns error message with server error if callback fails", func(t *testing.T) {
-		expectedErrs := types.MarshalErrors([]string{"boom"})
+		expectedErrs := types.MarshalErrorStrings("boom")
 
 		acb := func() ([]*types.Actor, error) {
 			return []*types.Actor{}, errors.New("boom")

--- a/handlers/v1/create_message_handler.go
+++ b/handlers/v1/create_message_handler.go
@@ -21,6 +21,7 @@ func (cmh *CreateMessageHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	if err := render.Bind(r, &newMsg); err != nil {
 		if err.Error() == "EOF" {
+			// message body was blank
 			err = errors.New("missing message parameters")
 		}
 		handlers.RespondBadRequest(w, err)

--- a/handlers/v1/create_message_handler_test.go
+++ b/handlers/v1/create_message_handler_test.go
@@ -13,39 +13,23 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	v1 "github.com/filecoin-project/go-http-api/handlers/v1"
+	"github.com/filecoin-project/go-http-api/handlers/v1"
+	"github.com/filecoin-project/go-http-api/test"
 	"github.com/filecoin-project/go-http-api/types"
 )
 
 func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 	uri := "http://localhost/chain/messages"
+	expectedMsg := types.Message{
+		To:         "someaddr",
+		Value:      big.NewInt(314),
+		GasPrice:   big.NewInt(1),
+		GasLimit:   uint64(300),
+		Method:     "updatePeerID",
+		Parameters: []string{"QmSTGFu1zZwrAvS8m9cWiZuuZ5pR33m85JJBuKnVPzX3u5"},
+	}
 
 	t.Run("Message is 'created' and returned if callback succeeds", func(t *testing.T) {
-		expectedMsg := types.Message{
-			To:         "someaddr",
-			Value:      big.NewInt(314),
-			GasPrice:   big.NewInt(1),
-			GasLimit:   uint64(300),
-			Method:     "updatePeerID",
-			Parameters: []string{"QmSTGFu1zZwrAvS8m9cWiZuuZ5pR33m85JJBuKnVPzX3u5"},
-		}
-
-		cb := func(message *types.Message) (*types.Message, error) {
-			expectedMsg = types.Message{
-				ID:         "sll3525ieiaghaQOEI582slkd0LKDFIeoiwRDeus",
-				Nonce:      878,
-				From:       "t27syykyps4puabw5fol3kn4n7flp44dz772hk3sq",
-				To:         message.To,
-				Value:      message.Value,
-				GasPrice:   message.GasPrice,
-				GasLimit:   message.GasLimit,
-				Method:     message.Method,
-				Parameters: message.Parameters,
-				Signature:  "STcLQ6ULcLreAhwCNtsd4GICPq9AN2JGJWa315zli4NqqphgOtxK4I",
-			}
-			return &expectedMsg, nil
-		}
-
 		jsonBody, err := json.Marshal(expectedMsg)
 		require.NoError(t, err)
 
@@ -53,7 +37,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		rr := httptest.NewRecorder()
 
-		handler := v1.CreateMessageHandler{Callback: cb}
+		handler := v1.CreateMessageHandler{Callback: happyPathCallback}
 		handler.ServeHTTP(rr, req)
 
 		var executedMsg types.Message
@@ -63,23 +47,30 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 		assert.Equal(t, expectedMsg, executedMsg)
 	})
 
-	t.Run("if body (message) is not provided, responds with error", func(t *testing.T) {
-		req := httptest.NewRequest("POST", uri, strings.NewReader(""))
-		req.Header.Set("Content-Type", "application/json")
+	t.Run("if callback fails, responds with error", func(t *testing.T) {
+		h := &v1.CreateMessageHandler{Callback: sadPathCallback}
 
-		req.PostForm = url.Values{}
-		rr := httptest.NewRecorder()
-		handler := v1.CreateMessageHandler{
-			Callback: func(*types.Message) (*types.Message, error) {
-				return &types.Message{}, errors.New("should not happen")
-			}}
-		handler.ServeHTTP(rr, req)
+		jsonBody, err := json.Marshal(expectedMsg)
+		require.NoError(t, err)
+
+		rr := test.PostTestRequest(uri, strings.NewReader(string(jsonBody[:])), h)
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+		expected := types.MarshalErrors([]string{"something"})
+
+		var actual types.APIErrorResponse
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
+		assert.Equal(t, expected, actual)
+
+	})
+
+	t.Run("if body (message) is not provided, responds with error", func(t *testing.T) {
+		h := &v1.CreateMessageHandler{Callback: happyPathCallback}
+		rr := test.PostTestRequest(uri, strings.NewReader(""), h)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-		expected := types.APIErrorResponse{Errors: []string{
-			"missing message parameters",
-		}}
+		expected := types.MarshalErrors([]string{"missing message parameters"})
 		var actual types.APIErrorResponse
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
 		assert.Equal(t, expected, actual)
@@ -94,10 +85,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 
 		req.PostForm = url.Values{}
 		rr := httptest.NewRecorder()
-		h := v1.CreateMessageHandler{
-			Callback: func(*types.Message) (*types.Message, error) {
-				return &types.Message{}, errors.New("should not happen")
-			}}
+		h := v1.CreateMessageHandler{Callback: happyPathCallback}
 		h.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -109,5 +97,25 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
 		assert.Equal(t, expected, actual)
 	})
+
+}
+
+func happyPathCallback(message *types.Message) (*types.Message, error) {
+	msg := types.Message{
+		ID:         "sll3525ieiaghaQOEI582slkd0LKDFIeoiwRDeus",
+		Nonce:      878,
+		From:       "t27syykyps4puabw5fol3kn4n7flp44dz772hk3sq",
+		To:         message.To,
+		Value:      message.Value,
+		GasPrice:   message.GasPrice,
+		GasLimit:   message.GasLimit,
+		Method:     message.Method,
+		Parameters: message.Parameters,
+	}
+	return &msg, nil
+}
+
+func sadPathCallback(message *types.Message) (*types.Message, error) {
+	return &types.Message{}, errors.New("should not happen")
 
 }

--- a/handlers/v1/create_message_handler_test.go
+++ b/handlers/v1/create_message_handler_test.go
@@ -42,6 +42,9 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 
 		var executedMsg types.Message
 		expectedMsg.Kind = "message"
+		expectedMsg.ID = "sll3525ieiaghaQOEI582slkd0LKDFIeoiwRDeus"
+		expectedMsg.From = "t27syykyps4puabw5fol3kn4n7flp44dz772hk3sq"
+		expectedMsg.Nonce = 878
 
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &executedMsg))
 		assert.Equal(t, expectedMsg, executedMsg)
@@ -56,11 +59,9 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 		rr := test.PostTestRequest(uri, strings.NewReader(string(jsonBody[:])), h)
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 
-		expected := types.MarshalErrors([]string{"something"})
+		expected := types.MarshalErrorStrings("boom")
 
-		var actual types.APIErrorResponse
-		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, expected, rr.Body.Bytes())
 
 	})
 
@@ -70,10 +71,8 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 
-		expected := types.MarshalErrors([]string{"missing message parameters"})
-		var actual types.APIErrorResponse
-		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
-		assert.Equal(t, expected, actual)
+		expected := types.MarshalErrorStrings("missing message parameters")
+		assert.Equal(t, expected, rr.Body.Bytes())
 	})
 
 	t.Run("if required parameters are not provided, responds with error", func(t *testing.T) {
@@ -91,7 +90,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 
 		expected := types.APIErrorResponse{Errors: []string{
-			"missing parameters: GasLimit,Method",
+			"missing parameters: Value,GasPrice,GasLimit,Method",
 		}}
 		var actual types.APIErrorResponse
 		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
@@ -116,6 +115,6 @@ func happyPathCallback(message *types.Message) (*types.Message, error) {
 }
 
 func sadPathCallback(message *types.Message) (*types.Message, error) {
-	return &types.Message{}, errors.New("should not happen")
+	return &types.Message{}, errors.New("boom")
 
 }

--- a/handlers/v1/default_handler.go
+++ b/handlers/v1/default_handler.go
@@ -10,8 +10,7 @@ import (
 // not provided a callback when the API was created.  Note this is distinct from
 // 404 Not Found which is the response to a request for a non-existent, unsupported
 // endpoint.
-type DefaultHandler struct {
-}
+type DefaultHandler struct{}
 
 // ServeHTTP handles an HTTP request.
 func (hh *DefaultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/handlers/v1/message_handler_test.go
+++ b/handlers/v1/message_handler_test.go
@@ -26,7 +26,6 @@ func TestMessageHandler_ServeHTTP(t *testing.T) {
 			GasLimit:   10,
 			Method:     "createMiner",
 			Parameters: nil,
-			Signature:  "somesig",
 		}
 		testcb := func(msgId string) (*types.Message, error) {
 			return &expected, nil

--- a/handlers/v1/signed_message_handler.go
+++ b/handlers/v1/signed_message_handler.go
@@ -1,0 +1,28 @@
+package v1
+
+import (
+	"errors"
+	"github.com/filecoin-project/go-http-api/handlers"
+	"github.com/filecoin-project/go-http-api/types"
+	"github.com/go-chi/render"
+	"net/http"
+)
+
+type SignedMessageHandler struct {
+	Callback func(*types.SignedMessage) (*types.Message, error)
+}
+
+func (ssmh *SignedMessageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var newMsg types.SignedMessage
+
+	if err := render.Bind(r, &newMsg); err != nil {
+		if err.Error() == "EOF" {
+			// message body was blank
+			err = errors.New("missing signed message")
+		}
+		handlers.RespondBadRequest(w, err)
+		return
+	}
+	executedMsg, err := ssmh.Callback(&newMsg)
+	handlers.Respond(w, executedMsg, err)
+}

--- a/handlers/v1/signed_message_handler.go
+++ b/handlers/v1/signed_message_handler.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SignedMessageHandler struct {
-	Callback func(*types.SignedMessage) (*types.Message, error)
+	Callback func(*types.SignedMessage) (*types.SignedMessage, error)
 }
 
 func (ssmh *SignedMessageHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/handlers/v1/signed_message_handler_test.go
+++ b/handlers/v1/signed_message_handler_test.go
@@ -1,0 +1,7 @@
+package v1
+
+import "testing"
+
+func TestSignedMessageHandler_ServeHTTP(t *testing.T) {
+
+}

--- a/handlers/v1/signed_message_handler_test.go
+++ b/handlers/v1/signed_message_handler_test.go
@@ -1,7 +1,52 @@
-package v1
+package v1_test
 
-import "testing"
+import (
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/filecoin-project/go-http-api/handlers/v1"
+	"github.com/filecoin-project/go-http-api/test"
+	"github.com/filecoin-project/go-http-api/test/fixtures"
+	"github.com/filecoin-project/go-http-api/types"
+	"github.com/stretchr/testify/require"
+)
 
 func TestSignedMessageHandler_ServeHTTP(t *testing.T) {
+	uri := "http://localhost/chain/signed-messages"
+	t.Run("message is sent and returned with extra fields filled out if callback succeeds", func(t *testing.T) {
+		expectedMsg := types.SignedMessage{
+			Message: types.Message{
+				Kind:       "message",
+				Nonce:      10,
+				From:       fixtures.TestAddress0,
+				To:         fixtures.TestAddress1,
+				Value:      big.NewInt(12),
+				GasPrice:   big.NewInt(1),
+				GasLimit:   uint64(300),
+				Method:     "updatePeerID",
+				Parameters: []string{},
+			},
+			Signature: "abcd1234",
+		}
+		h := &v1.SignedMessageHandler{Callback: happyPathSMCallback}
+		jsonBody, err := json.Marshal(expectedMsg)
+		require.NoError(t, err)
+		rr := test.PostTestRequest(uri, strings.NewReader(string(jsonBody[:])), h)
+		require.NotNil(t, rr)
+	})
 
+	t.Run("missing params returns an error", func(t *testing.T) {
+
+	})
 }
+
+func happyPathSMCallback(sm *types.SignedMessage) (*types.SignedMessage, error) {
+	sm.ID = "SLDFKJSLDFKJSDLFKJSDFLMESSAGEID"
+	return sm, nil
+}
+
+//func sadPathSMCallback(message *types.SignedMessage) (*types.SignedMessage, error) {
+//	return nil, errors.New("boom")
+//}

--- a/handlers/v1/signed_message_handler_test.go
+++ b/handlers/v1/signed_message_handler_test.go
@@ -2,51 +2,86 @@ package v1_test
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/filecoin-project/go-http-api/handlers/v1"
 	"github.com/filecoin-project/go-http-api/test"
 	"github.com/filecoin-project/go-http-api/test/fixtures"
 	"github.com/filecoin-project/go-http-api/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestSignedMessageHandler_ServeHTTP(t *testing.T) {
 	uri := "http://localhost/chain/signed-messages"
+	signedMessage := types.SignedMessage{
+		Nonce:      10,
+		From:       fixtures.TestAddress0,
+		To:         fixtures.TestAddress1,
+		Value:      big.NewInt(12),
+		GasPrice:   big.NewInt(1),
+		GasLimit:   uint64(300),
+		Method:     "updatePeerID",
+		Parameters: []string{},
+		Signature:  "abcd1234",
+	}
 	t.Run("message is sent and returned with extra fields filled out if callback succeeds", func(t *testing.T) {
-		expectedMsg := types.SignedMessage{
-			Message: types.Message{
-				Kind:       "message",
-				Nonce:      10,
-				From:       fixtures.TestAddress0,
-				To:         fixtures.TestAddress1,
-				Value:      big.NewInt(12),
-				GasPrice:   big.NewInt(1),
-				GasLimit:   uint64(300),
-				Method:     "updatePeerID",
-				Parameters: []string{},
-			},
-			Signature: "abcd1234",
-		}
+
 		h := &v1.SignedMessageHandler{Callback: happyPathSMCallback}
-		jsonBody, err := json.Marshal(expectedMsg)
+		jsonBody, err := json.Marshal(signedMessage)
 		require.NoError(t, err)
 		rr := test.PostTestRequest(uri, strings.NewReader(string(jsonBody[:])), h)
 		require.NotNil(t, rr)
+		assert.Equal(t, http.StatusOK, rr.Code)
+
+		signedMessage.Kind = "signedMessage"
+		signedMessage.ID = "MESSAGEID"
+
+		var actualMsg types.SignedMessage
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actualMsg))
+		assert.Equal(t, signedMessage, actualMsg)
 	})
 
-	t.Run("missing params returns an error", func(t *testing.T) {
+	t.Run("missing params returns an error  code 400", func(t *testing.T) {
+		msg := types.SignedMessage{
+			To:        fixtures.TestAddress0,
+			Signature: "abcd123",
+		}
 
+		msgBody, err := json.Marshal(msg)
+		require.NoError(t, err)
+		h := &v1.SignedMessageHandler{Callback: happyPathSMCallback}
+		rr := test.PostTestRequest(uri, strings.NewReader(string(msgBody[:])), h)
+
+		expBody := types.MarshalErrorStrings("missing parameters: From,Value,GasPrice,GasLimit,Method")
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+		assert.Equal(t, expBody, rr.Body.Bytes())
+	})
+
+	t.Run("when callback returns error, it is returned with code 500", func(t *testing.T) {
+		msgBody, err := json.Marshal(signedMessage)
+		require.NoError(t, err)
+		h := &v1.SignedMessageHandler{Callback: sadPathSMCallback}
+		rr := test.PostTestRequest(uri, strings.NewReader(string(msgBody[:])), h)
+
+		expBody := types.MarshalErrorStrings("boom")
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, expBody, rr.Body.Bytes())
 	})
 }
 
 func happyPathSMCallback(sm *types.SignedMessage) (*types.SignedMessage, error) {
-	sm.ID = "SLDFKJSLDFKJSDLFKJSDFLMESSAGEID"
-	return sm, nil
+	execMsg := *sm
+	execMsg.Kind = "signedMessage"
+	execMsg.ID = "MESSAGEID"
+	return &execMsg, nil
 }
 
-//func sadPathSMCallback(message *types.SignedMessage) (*types.SignedMessage, error) {
-//	return nil, errors.New("boom")
-//}
+func sadPathSMCallback(_ *types.SignedMessage) (*types.SignedMessage, error) {
+	return nil, errors.New("boom")
+}

--- a/handlers/v1/v1.go
+++ b/handlers/v1/v1.go
@@ -2,7 +2,9 @@ package v1
 
 import (
 	"github.com/filecoin-project/go-http-api/types"
+	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log"
+	"math/big"
 	"net/http"
 	"reflect"
 )
@@ -18,13 +20,15 @@ var log = logging.Logger("rest-api-handlers")
 //   * Add a new callback name/signature to Callbacks
 //   * Add a case to BuildHandlers that uses the callback
 type Callbacks struct {
-	GetActorByID      func(string) (*types.Actor, error)
-	GetActors         func() ([]*types.Actor, error)
-	GetBlockByID      func(string) (*types.Block, error)
-	CreateMessage     func(*types.Message) (*types.Message, error)
-	SendSignedMessage func(*types.SignedMessage) (*types.Message, error)
-	GetMessageByID    func(string) (*types.Message, error)
-	GetNode           func() (*types.Node, error)
+	GetActorByID        func(string) (*types.Actor, error)
+	GetActors           func() ([]*types.Actor, error)
+	GetBlockByID        func(string) (*types.Block, error)
+	CreateMessage       func(*types.Message) (*types.Message, error)
+	CreateSignedMessage func(*types.SignedMessage) (*types.SignedMessage, error)
+	GetMessageByID      func(string) (*types.Message, error)
+	GetNode             func() (*types.Node, error)
+	SendSignedMessage   func(*types.SignedMessage) (*types.SignedMessage, error)
+	WaitForMessage      func(cid *cid.Cid, limitBH *big.Int) (bH *big.Int, err error)
 }
 
 // BuildHandlers takes a V1Callback struct and iterates over all

--- a/handlers/v1/v1.go
+++ b/handlers/v1/v1.go
@@ -3,22 +3,63 @@ package v1
 import (
 	"github.com/filecoin-project/go-http-api/types"
 	logging "github.com/ipfs/go-log"
+	"net/http"
+	"reflect"
 )
 
 // For needed package-level items
 var log = logging.Logger("rest-api-handlers")
 
-// Callbacks is a struct for callbacks configurable for the given API endpoint,
-// shown by the 'path' tag
+// Callbacks is a struct for callbacks to be used for an API endpoint.
+// This is a struct rather than an interface so implementers do not have to write their own
+// version of every callback.  Missing callbacks will cause a DefaultHandler to be used.
 // To add a new endpoint:
 //   * Write a new handler to use a new V1Callback, with tests
 //   * Add a new callback name/signature to Callbacks
-//   * Add a case to SetupV1Handlers that uses the callback
+//   * Add a case to BuildHandlers that uses the callback
 type Callbacks struct {
-	GetActorByID   func(string) (*types.Actor, error)
-	GetActors      func() ([]*types.Actor, error)
-	GetBlockByID   func(string) (*types.Block, error)
-	CreateMessage  func(*types.Message) (*types.Message, error)
-	GetMessageByID func(string) (*types.Message, error)
-	GetNode        func() (*types.Node, error)
+	GetActorByID      func(string) (*types.Actor, error)
+	GetActors         func() ([]*types.Actor, error)
+	GetBlockByID      func(string) (*types.Block, error)
+	CreateMessage     func(*types.Message) (*types.Message, error)
+	SendSignedMessage func(*types.SignedMessage) (*types.Message, error)
+	GetMessageByID    func(string) (*types.Message, error)
+	GetNode           func() (*types.Node, error)
+}
+
+// BuildHandlers takes a V1Callback struct and iterates over all
+// functions, creating a handler with a callback for each supported endpoint.
+func (cb *Callbacks) BuildHandlers() *map[string]http.Handler {
+	cb1t := reflect.TypeOf(*cb)
+	cb1v := reflect.ValueOf(*cb)
+
+	numCallbacks := cb1t.NumField()
+	handlers := make(map[string]http.Handler, numCallbacks)
+
+	for i := 0; i < numCallbacks; i++ {
+		fieldName := cb1t.Field(i).Name
+
+		fieldValue := cb1v.Field(i)
+		if fieldValue.IsNil() {
+			handlers[fieldName] = &DefaultHandler{}
+		} else {
+			switch fieldName {
+			case "GetBlockByID":
+				handlers[fieldName] = &BlockHandler{Callback: cb.GetBlockByID}
+			case "GetActors":
+				handlers[fieldName] = &ActorsHandler{Callback: cb.GetActors}
+			case "GetActorByID":
+				handlers[fieldName] = &ActorHandler{Callback: cb.GetActorByID}
+			case "CreateMessage":
+				handlers[fieldName] = &CreateMessageHandler{Callback: cb.CreateMessage}
+			case "GetMessageByID":
+				handlers[fieldName] = &MessageHandler{Callback: cb.GetMessageByID}
+			case "GetNode":
+				handlers[fieldName] = &NodeHandler{Callback: cb.GetNode}
+			default:
+				log.Errorf("skipping unknown handler: %s.", fieldName)
+			}
+		}
+	}
+	return &handlers
 }

--- a/test/util.go
+++ b/test/util.go
@@ -5,10 +5,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"github.com/go-chi/chi"
+	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -125,4 +127,13 @@ func TestGetHandler(h http.Handler, uri string, params *[]Param) (*http.Response
 
 	h.ServeHTTP(w, r)
 	return w.Result(), w.Body.Bytes()
+}
+
+func PostTestRequest(uri string, body io.Reader, h http.Handler) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", uri, body)
+	req.Header.Set("Content-Type", "application/json")
+	req.PostForm = url.Values{}
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	return rr
 }

--- a/types/api_error.go
+++ b/types/api_error.go
@@ -14,8 +14,8 @@ func IrrecoverableError() APIErrorResponse {
 	return APIErrorResponse{Errors: []string{"irrecoverable error"}}
 }
 
-// MarshalErrors takes a list of strings, and returns a marshaled APIErrorResponse
-func MarshalErrors(errlist []string) []byte {
+// MarshalErrorStrings takes a list of strings, and returns a marshaled APIErrorResponse
+func MarshalErrorStrings(errlist ...string) []byte {
 	errs := APIErrorResponse{Errors: errlist}
 	res, err := json.Marshal(errs)
 	if err != nil {
@@ -26,5 +26,5 @@ func MarshalErrors(errlist []string) []byte {
 
 // MarshalError takes an error and returns a marshaled APIErrorResponse
 func MarshalError(err error) []byte {
-	return MarshalErrors([]string{err.Error()})
+	return MarshalErrorStrings(err.Error())
 }

--- a/types/api_error_test.go
+++ b/types/api_error_test.go
@@ -16,5 +16,5 @@ func TestMarshalErrors(t *testing.T) {
 
 	testErrJSON, _ := json.Marshal(testErr)
 
-	assert.Equal(t, types.MarshalErrors(msgs), testErrJSON)
+	assert.Equal(t, types.MarshalErrorStrings("a", "b"), testErrJSON)
 }

--- a/types/message.go
+++ b/types/message.go
@@ -19,7 +19,6 @@ type Message struct {
 	GasLimit   uint64   `json:"gasLimit,required,omitempty"` // in GasUnits
 	Method     string   `json:"method,required,omitempty"`
 	Parameters []string `json:"parameters,required"`
-	Signature  string   `json:"signature,omitempty"`
 }
 
 func (m Message) MarshalJSON() ([]byte, error) {
@@ -30,5 +29,5 @@ func (m Message) MarshalJSON() ([]byte, error) {
 }
 
 func (m *Message) Bind(r *http.Request) error {
-	return RequireFields(m, "To", "Value", "GasPrice", "GasLimit", "Method")
+	return RequireFields(m, "To", "Value", "GasPrice", "GasLimit", "Method", "Parameters")
 }

--- a/types/message.go
+++ b/types/message.go
@@ -9,16 +9,16 @@ import (
 // Message is a struct representing a Filecoin message.
 // Parameter are parameters for the Method from the HTTP request and are passed to the Callback unparsed.
 type Message struct {
-	Kind       string   `json:"kind,required,omitempty"`
+	Kind       string   `json:"kind,omitempty"`
 	ID         string   `json:"id,omitempty"`
 	Nonce      uint64   `json:"nonce,omitempty"`
 	From       string   `json:"from,omitempty"`
-	To         string   `json:"to,required,omitempty"`
-	Value      *big.Int `json:"value,required,omitempty"`    // in AttoFIL
-	GasPrice   *big.Int `json:"gasPrice,required,omitempty"` // in AttoFIL
-	GasLimit   uint64   `json:"gasLimit,required,omitempty"` // in GasUnits
-	Method     string   `json:"method,required,omitempty"`
-	Parameters []string `json:"parameters,required"`
+	To         string   `json:"to,omitempty"`
+	Value      *big.Int `json:"value,omitempty"`    // in AttoFIL
+	GasPrice   *big.Int `json:"gasPrice,omitempty"` // in AttoFIL
+	GasLimit   uint64   `json:"gasLimit,omitempty"` // in GasUnits
+	Method     string   `json:"method,omitempty"`
+	Parameters []string `json:"parameters,omitempty"`
 }
 
 func (m Message) MarshalJSON() ([]byte, error) {
@@ -29,5 +29,5 @@ func (m Message) MarshalJSON() ([]byte, error) {
 }
 
 func (m *Message) Bind(r *http.Request) error {
-	return RequireFields(m, "To", "Value", "GasPrice", "GasLimit", "Method", "Parameters")
+	return RequireFields(m, "To", "Value", "GasPrice", "GasLimit", "Method")
 }

--- a/types/message.go
+++ b/types/message.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 )
 
+// Message is a struct representing a Filecoin message.
+// Parameter are parameters for the Method from the HTTP request and are passed to the Callback unparsed.
 type Message struct {
 	Kind       string   `json:"kind,required,omitempty"`
 	ID         string   `json:"id,omitempty"`

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -1,15 +1,28 @@
 package types
 
 import (
+	"math/big"
 	"net/http"
 )
 
 // SignedMessage is a struct representing a signed message to be posted in the message pool.
+// Unlike filecoin implementations, this does not embed Message and add Sigature,
+// because of the need  to marshal as JSON.  Embedding Message causes json.Marshal to strip the Signature field.
+// This is unlikely to be fixed: https://github.com/golang/go/issues/31167
 type SignedMessage struct {
-	Message
-	Signature string `json:"signature,omitempty"`
+	Kind       string   `json:"kind,omitempty"`
+	ID         string   `json:"id,omitempty"`
+	Nonce      uint64   `json:"nonce,omitempty"`
+	From       string   `json:"from,omitempty"`
+	To         string   `json:"to,omitempty"`
+	Value      *big.Int `json:"value,omitempty"`    // in AttoFIL
+	GasPrice   *big.Int `json:"gasPrice,omitempty"` // in AttoFIL
+	GasLimit   uint64   `json:"gasLimit,omitempty"` // in GasUnits
+	Method     string   `json:"method,omitempty"`
+	Parameters []string `json:"parameters"`
+	Signature  string   `json:"signature,omitempty"`
 }
 
 func (sm *SignedMessage) Bind(r *http.Request) error {
-	return RequireFields(sm, "To", "Value", "GasPrice", "GasLimit", "Method", "Parameters", "Signature")
+	return RequireFields(sm, "To", "From", "Value", "GasPrice", "GasLimit", "Method", "Signature")
 }

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"errors"
+	"net/http"
+)
+
+// SignedMessage is a struct representing a complete signed message in binary format,
+// sent to the HTTP API as Content-Type: application/octet-stream
+type SignedMessage struct {
+	MessageBlob []byte `json:"messageBlob,required"`
+}
+
+func (sm *SignedMessage) Bind(r *http.Request) error {
+	if len(sm.MessageBlob) == 0 {
+		return errors.New("messageBlob is missing")
+	}
+	return nil
+}

--- a/types/signed_message.go
+++ b/types/signed_message.go
@@ -1,19 +1,15 @@
 package types
 
 import (
-	"errors"
 	"net/http"
 )
 
-// SignedMessage is a struct representing a complete signed message in binary format,
-// sent to the HTTP API as Content-Type: application/octet-stream
+// SignedMessage is a struct representing a signed message to be posted in the message pool.
 type SignedMessage struct {
-	MessageBlob []byte `json:"messageBlob,required"`
+	Message
+	Signature string `json:"signature,omitempty"`
 }
 
 func (sm *SignedMessage) Bind(r *http.Request) error {
-	if len(sm.MessageBlob) == 0 {
-		return errors.New("messageBlob is missing")
-	}
-	return nil
+	return RequireFields(sm, "To", "Value", "GasPrice", "GasLimit", "Method", "Parameters", "Signature")
 }

--- a/types/validate.go
+++ b/types/validate.go
@@ -9,12 +9,30 @@ import (
 func RequireFields(m interface{}, params ...string) error {
 	var missing []string
 	mval := reflect.ValueOf(m)
-	for _, el := range params {
-		val := reflect.Indirect(mval).FieldByName(el)
-		valType := val.Type().Name()
-		if valType == "string" && val.Interface().(string) == "" ||
-			valType == "uint64" && val.Interface().(uint64) == 0 {
-			missing = append(missing, el)
+	for _, param := range params {
+		val := reflect.Indirect(mval).FieldByName(param)
+		valKind := val.Kind().String()
+		isMissing := false
+		switch valKind {
+		case "string":
+			if val.Interface().(string) == "" {
+				isMissing = true
+			}
+		case "uint64":
+			if val.Interface().(uint64) == 0 {
+				isMissing = true
+			}
+		case "ptr":
+			if val.IsNil() {
+				isMissing = true
+			}
+		case "slice":
+			if val.IsNil() {
+				isMissing = true
+			}
+		}
+		if isMissing {
+			missing = append(missing, param)
 		}
 	}
 	if len(missing) > 0 {


### PR DESCRIPTION
# Feature: Sending of signed messages
Full support of this feature requires a second endpoint for requesting the From actor `Nonce`. This will happen in a follow-up PR.

Also:
* Clarify error marshalling functions  and make `MarshalErrorStrings` have variadic string list for convenience
* Better tests for` CreateMessage/Handler`
* Move v1 handlers into v1 package
* Remove "required" from json tags
* Correct bugs and add types in `RequireFields`