### PR TITLE
Actor nonce endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-log v0.0.1
+	github.com/magiconair/properties v1.8.0
 	github.com/multiformats/go-multihash v0.0.1
 	github.com/stretchr/testify v1.4.0
 	rsc.io/quote v1.5.2

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/ipfs/go-cid v0.0.3
 	github.com/ipfs/go-log v0.0.1
-	github.com/magiconair/properties v1.8.0
 	github.com/multiformats/go-multihash v0.0.1
 	github.com/stretchr/testify v1.4.0
 	rsc.io/quote v1.5.2

--- a/handlers/v1/actor_handler_test.go
+++ b/handlers/v1/actor_handler_test.go
@@ -26,12 +26,12 @@ func TestActor_ServeHTTP(t *testing.T) {
 		}}
 		params := &[]test.Param{{Key: "actorId", Value: "1111"}}
 
-		resp, body := test.TestGetHandler(h, uri, params)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		rr := test.GetTestRequest(uri, params, h)
+		assert.Equal(t, http.StatusOK, rr.Code)
 
 		fa.Kind = "actor"
 		var actual types.Actor
-		require.NoError(t, json.Unmarshal(body, &actual))
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
 		assert.Equal(t, *fa, actual)
 	})
 
@@ -41,12 +41,12 @@ func TestActor_ServeHTTP(t *testing.T) {
 		acb := func(actorId string) (*types.Actor, error) {
 			return nil, errors.New("this is an error")
 		}
-		h := v1.ActorHandler{Callback: acb}
-		params := []test.Param{{Key: "actorId", Value: "1111"}}
+		h := &v1.ActorHandler{Callback: acb}
+		params := &[]test.Param{{Key: "actorId", Value: "1111"}}
 
-		resp, body := test.TestGetHandler(&h, uri, &params)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.Equal(t, errs, body)
+		rr := test.GetTestRequest(uri, params, h)
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, errs, rr.Body.Bytes())
 	})
 }
 
@@ -76,6 +76,6 @@ func requireCreateTestActor(t *testing.T, addr string) *types.Actor {
 		Address:   addr,
 		Balance:   big.NewInt(600),
 		Code:      test.RequireTestCID(t, []byte("anything")),
-		Nonce:     123434,
+		Nonce:     big.NewInt(123434),
 	}
 }

--- a/handlers/v1/actor_nonce_handler.go
+++ b/handlers/v1/actor_nonce_handler.go
@@ -1,0 +1,21 @@
+package v1
+
+import (
+	"math/big"
+	"net/http"
+
+	"github.com/go-chi/chi"
+
+	"github.com/filecoin-project/go-http-api/handlers"
+)
+
+type ActorNonceHandler struct {
+	Callback func(string) (*big.Int, error)
+}
+
+func (anh *ActorNonceHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	actorId := chi.URLParam(r, "actorId")
+
+	actor, err := anh.Callback(actorId)
+	handlers.Respond(w, actor, err)
+}

--- a/handlers/v1/actor_nonce_handler_test.go
+++ b/handlers/v1/actor_nonce_handler_test.go
@@ -1,0 +1,53 @@
+package v1_test
+
+import (
+	"errors"
+	"math/big"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/filecoin-project/go-http-api/handlers/v1"
+	"github.com/filecoin-project/go-http-api/test"
+	"github.com/filecoin-project/go-http-api/types"
+)
+
+func TestActorNonceHandler_ServeHTTP(t *testing.T) {
+	uri := "http://localhost:3000/actors/1234/nonce"
+
+	t.Run("returns actor nonce when requested", func(t *testing.T) {
+		h := &v1.ActorNonceHandler{Callback: happyPathANCallback}
+		rr := test.GetTestRequest(uri, nil, h)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "1234", rr.Body.String())
+	})
+
+	t.Run("returns error if callback fails", func(t *testing.T) {
+		h := &v1.ActorNonceHandler{Callback: sadPathANCallback}
+		rr := test.GetTestRequest(uri, nil, h)
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		exp := types.MarshalErrorStrings("boom")
+		assert.Equal(t, exp, rr.Body.Bytes())
+	})
+
+	t.Run("returns actor nonce via server", func(t *testing.T) {
+		cbs := v1.Callbacks{GetActorNonce: happyPathANCallback}
+
+		s := test.CreateTestServer(t, &cbs, false).Run()
+		defer func() {
+			assert.NoError(t, s.Shutdown())
+		}()
+		body := test.RequireGetResponseBody(t, s.Config().Port, "actors/1234/nonce")
+
+		assert.Equal(t, "1234", string(body[:]))
+	})
+}
+
+func happyPathANCallback(_ string) (*big.Int, error) {
+	return big.NewInt(1234), nil
+}
+
+func sadPathANCallback(_ string) (*big.Int, error) {
+	return nil, errors.New("boom")
+}

--- a/handlers/v1/actors_handler_test.go
+++ b/handlers/v1/actors_handler_test.go
@@ -24,14 +24,14 @@ func TestActorsHandler_ServeHTTP(t *testing.T) {
 			Address:   fixtures.TestAddress0,
 			Balance:   big.NewInt(600),
 			Code:      test.RequireTestCID(t, []byte("actor1")),
-			Nonce:     21,
+			Nonce:     big.NewInt(21),
 			Head:      test.RequireTestCID(t, []byte("head")),
 		}
 		a2 := types.Actor{
 			ActorType: "miner",
 			Address:   fixtures.TestAddress1,
 			Code:      test.RequireTestCID(t, []byte("actor2")),
-			Nonce:     10,
+			Nonce:     big.NewInt(10),
 			Balance:   big.NewInt(2100),
 			Head:      test.RequireTestCID(t, []byte("head1")),
 		}
@@ -42,12 +42,12 @@ func TestActorsHandler_ServeHTTP(t *testing.T) {
 			return []*types.Actor{&a1, &a2}, nil
 		}
 
-		h := v1.ActorsHandler{Callback: acb}
-		resp, body := test.TestGetHandler(&h, path, nil)
+		h := &v1.ActorsHandler{Callback: acb}
+		rr := test.GetTestRequest(path, nil, h)
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, rr.Code)
 		var actual []types.Actor
-		require.NoError(t, json.Unmarshal(body, &actual))
+		require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &actual))
 
 		require.Len(t, actual, 2)
 		assert.Equal(t, a1, actual[0])
@@ -61,9 +61,9 @@ func TestActorsHandler_ServeHTTP(t *testing.T) {
 			return []*types.Actor{}, errors.New("boom")
 		}
 
-		h := v1.ActorsHandler{Callback: acb}
-		resp, body := test.TestGetHandler(&h, path, nil)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		assert.Equal(t, expectedErrs, body)
+		h := &v1.ActorsHandler{Callback: acb}
+		rr := test.GetTestRequest(path, nil, h)
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
+		assert.Equal(t, expectedErrs, rr.Body.Bytes())
 	})
 }

--- a/handlers/v1/block_handler_test.go
+++ b/handlers/v1/block_handler_test.go
@@ -25,13 +25,13 @@ func TestBlockHandler_ServeHTTP(t *testing.T) {
 		h := &v1.BlockHandler{Callback: func(blockId string) (*types.Block, error) {
 			return tb, nil
 		}}
-		resp, body := test.TestGetHandler(h, uri, &params)
+		rr := test.GetTestRequest(uri, &params, h)
 
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusOK, rr.Code)
 
 		tb.Kind = "block"
 		expected, _ := json.Marshal(*tb)
-		assert.Equal(t, expected, body)
+		assert.Equal(t, expected, rr.Body.Bytes())
 	})
 
 	t.Run("if callback errors, returns server error status + error msg", func(t *testing.T) {
@@ -39,11 +39,11 @@ func TestBlockHandler_ServeHTTP(t *testing.T) {
 		h := &v1.BlockHandler{Callback: func(blockId string) (*types.Block, error) {
 			return &types.Block{}, err
 		}}
-		resp, body := test.TestGetHandler(h, uri, &params)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		rr := test.GetTestRequest(uri, &params, h)
+		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 
 		expected := types.MarshalError(err)
-		assert.Equal(t, expected, body)
+		assert.Equal(t, expected, rr.Body.Bytes())
 	})
 }
 

--- a/handlers/v1/create_message_handler_test.go
+++ b/handlers/v1/create_message_handler_test.go
@@ -37,7 +37,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		rr := httptest.NewRecorder()
 
-		handler := v1.CreateMessageHandler{Callback: happyPathCallback}
+		handler := v1.CreateMessageHandler{Callback: happyPathCMCallback}
 		handler.ServeHTTP(rr, req)
 
 		var executedMsg types.Message
@@ -51,7 +51,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("if callback fails, responds with error", func(t *testing.T) {
-		h := &v1.CreateMessageHandler{Callback: sadPathCallback}
+		h := &v1.CreateMessageHandler{Callback: sadPathCMCallback}
 
 		jsonBody, err := json.Marshal(expectedMsg)
 		require.NoError(t, err)
@@ -66,7 +66,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 	})
 
 	t.Run("if body (message) is not provided, responds with error", func(t *testing.T) {
-		h := &v1.CreateMessageHandler{Callback: happyPathCallback}
+		h := &v1.CreateMessageHandler{Callback: happyPathCMCallback}
 		rr := test.PostTestRequest(uri, strings.NewReader(""), h)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -84,7 +84,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 
 		req.PostForm = url.Values{}
 		rr := httptest.NewRecorder()
-		h := v1.CreateMessageHandler{Callback: happyPathCallback}
+		h := v1.CreateMessageHandler{Callback: happyPathCMCallback}
 		h.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -99,7 +99,7 @@ func TestCreateMessageHandler_ServeHTTP(t *testing.T) {
 
 }
 
-func happyPathCallback(message *types.Message) (*types.Message, error) {
+func happyPathCMCallback(message *types.Message) (*types.Message, error) {
 	msg := types.Message{
 		ID:         "sll3525ieiaghaQOEI582slkd0LKDFIeoiwRDeus",
 		Nonce:      878,
@@ -114,7 +114,7 @@ func happyPathCallback(message *types.Message) (*types.Message, error) {
 	return &msg, nil
 }
 
-func sadPathCallback(message *types.Message) (*types.Message, error) {
+func sadPathCMCallback(message *types.Message) (*types.Message, error) {
 	return &types.Message{}, errors.New("boom")
 
 }

--- a/server.go
+++ b/server.go
@@ -97,7 +97,10 @@ func (s *HTTPAPI) Route() {
 		})
 		r.Route("/actors", func(r chi.Router) {
 			r.Get("/", handlers["GetActors"].ServeHTTP)
-			r.Get("/{actorId}", handlers["GetActorByID"].ServeHTTP)
+			r.Route("/{actorId}", func(r chi.Router) {
+				r.Get("/", handlers["GetActorByID"].ServeHTTP)
+				r.Get("/nonce", handlers["GetActorNonce"].ServeHTTP)
+			})
 		})
 	})
 }

--- a/test/util.go
+++ b/test/util.go
@@ -112,9 +112,9 @@ func AssertServerResponse(t *testing.T, callbacks *v1.Callbacks, ssl bool, path 
 	AssertGetResponseBody(t, s.Config().Port, ssl, path, expected)
 }
 
-func TestGetHandler(h http.Handler, uri string, params *[]Param) (*http.Response, []byte) {
-	r, _ := http.NewRequest("GET", uri, nil)
-	w := httptest.NewRecorder()
+func GetTestRequest(uri string, params *[]Param, h http.Handler) *httptest.ResponseRecorder {
+	req, _ := http.NewRequest("GET", uri, nil)
+	rr := httptest.NewRecorder()
 
 	rctx := chi.NewRouteContext()
 	if params != nil {
@@ -123,10 +123,10 @@ func TestGetHandler(h http.Handler, uri string, params *[]Param) (*http.Response
 		}
 	}
 
-	r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 
-	h.ServeHTTP(w, r)
-	return w.Result(), w.Body.Bytes()
+	h.ServeHTTP(rr, req)
+	return rr
 }
 
 func PostTestRequest(uri string, body io.Reader, h http.Handler) *httptest.ResponseRecorder {

--- a/types/actor.go
+++ b/types/actor.go
@@ -15,10 +15,10 @@ type readableFunctionSignature struct {
 // Actor is a struct for a Filecoin actor
 type Actor struct {
 	Kind      string                               `json:"kind,required,omitempty"`
-	ActorType string                               `json:"actorType,omitempty"`
+	ActorType string                               `json:"role,omitempty"`
 	Address   string                               `json:"address,omitempty"`
 	Code      cid.Cid                              `json:"code,omitempty"`
-	Nonce     uint64                               `json:"nonce,omitempty"`
+	Nonce     *big.Int                             `json:"nonce,omitempty"`
 	Balance   *big.Int                             `json:"balance,omitempty"`
 	Exports   map[string]readableFunctionSignature `json:"exports,omitempty"` // exports by function name
 	Head      cid.Cid                              `json:"head,omitempty"`


### PR DESCRIPTION
# Problem
Callers of HTTP API that want to send signed messages will need to know the correct nonce in order to create a signed message. 

# Solution
Currently they could just call the standard actor/{actorId} endpoint . Since all they want is the nonce and no other info, this implements a convenience endpoint which allows them to get just this and not have to deserialize into an Actor struct, and instead convert the response directly to a numeric type.   The nonce itself may be pulled from a cache rather than having to fetch the Actor Info and may result in a slightly faster turnaround.

Also:
* Converts Actor testsuite to use httptest
* Changes the numeric type of Nonce from uint64 to *big.Int to be like the others.